### PR TITLE
Implement client category filtering

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -13,12 +13,29 @@ class RegisterForm(FlaskForm):
     password  = PasswordField("Password", validators=[DataRequired(), Length(min=6)])
     password2 = PasswordField("Confirm",  validators=[DataRequired(), EqualTo('password')])
     role      = SelectField("Role", choices=[("client", "Client"), ("master", "Master")])
+    category  = SelectField(
+        "Category",
+        choices=[
+            ("hoikuen", "保育園"),
+            ("nintei_kodomoen", "認定こども園"),
+            ("youchien", "幼稚園"),
+        ],
+    )
     submit    = SubmitField("Register")
 
 class TemplateForm(FlaskForm):
     title = StringField("Title",        validators=[DataRequired()])
     description = TextAreaField("Description", validators=[DataRequired()])
     file  = FileField("Template File",  validators=[DataRequired()])
+    category = SelectField(
+        "Category",
+        choices=[
+            ("hoikuen", "保育園"),
+            ("nintei_kodomoen", "認定こども園"),
+            ("youchien", "幼稚園"),
+        ],
+        validators=[DataRequired()],
+    )
     submit = SubmitField("Create")
 
 class UploadForm(FlaskForm):

--- a/app/models.py
+++ b/app/models.py
@@ -17,6 +17,11 @@ class Status(enum.Enum):
     confirmed     = "確認済み"
     resubmit      = "再提出"
 
+class ClientCategory(enum.Enum):
+    hoikuen         = "保育園"
+    nintei_kodomoen = "認定こども園"
+    youchien        = "幼稚園"
+
 # ─── ユーザ ───────────────────────────────────────────────────────────
 
 class User(UserMixin, db.Model):
@@ -24,6 +29,7 @@ class User(UserMixin, db.Model):
     email         = db.Column(db.String(120), unique=True, nullable=False)
     password_hash = db.Column(db.String(128), nullable=False)
     role          = db.Column(db.Enum(Role), default=Role.client, nullable=False)
+    category      = db.Column(db.Enum(ClientCategory))
     created_at    = db.Column(db.DateTime, default=datetime.utcnow)
 
     # パスワードヘルパ
@@ -41,6 +47,7 @@ class Template(db.Model):
     title       = db.Column(db.String(120), nullable=False)
     description = db.Column(db.Text, nullable=False)
     filename    = db.Column(db.String(200), nullable=False)  # 保存パス
+    category    = db.Column(db.Enum(ClientCategory))
     owner_id    = db.Column(db.Integer, db.ForeignKey("user.id"))
     owner       = db.relationship("User", foreign_keys=[owner_id])
     created_at  = db.Column(db.DateTime, default=datetime.utcnow)

--- a/app/routes/auth.py
+++ b/app/routes/auth.py
@@ -1,7 +1,7 @@
 from flask import Blueprint, render_template, redirect, url_for, flash
 from flask_login import login_user, logout_user
 from ..forms import LoginForm, RegisterForm
-from ..models import User, db, Role
+from ..models import User, db, Role, ClientCategory
 
 bp = Blueprint("auth", __name__)
 
@@ -25,8 +25,12 @@ def register():
         if User.query.filter_by(email=form.email.data.lower()).first():
             flash("Email already registered", "warning")
         else:
-            user = User(email=form.email.data.lower(),
-                        role=Role[form.role.data])
+            user = User(
+                email=form.email.data.lower(),
+                role=Role[form.role.data],
+            )
+            if user.role == Role.client:
+                user.category = ClientCategory[form.category.data]
             user.set_password(form.password.data)
             db.session.add(user)
             db.session.commit()

--- a/app/routes/main.py
+++ b/app/routes/main.py
@@ -5,7 +5,7 @@ from flask import (Blueprint, render_template, redirect, url_for, flash,
 from flask_login import login_required, current_user
 from werkzeug.utils import secure_filename
 from ..forms import TemplateForm, UploadForm, ReviewForm
-from ..models import db, Template, Submission, Status, Role
+from ..models import db, Template, Submission, Status, Role, ClientCategory
 
 bp = Blueprint("main", __name__)
 
@@ -21,9 +21,10 @@ def allowed_file(filename):
 def dashboard():
     if current_user.role == Role.master:
         templates = Template.query.filter_by(owner_id=current_user.id).all()
-        return render_template("dashboard_master.html", templates=templates)
+        return render_template("dashboard_master.html", templates=templates,
+                               ClientCategory=ClientCategory)
     else:
-        templates = Template.query.all()
+        templates = Template.query.filter_by(category=current_user.category).all()
         submissions = {s.template_id: s for s in
                        Submission.query.filter_by(client_id=current_user.id).all()}
         return render_template("dashboard_client.html",
@@ -63,6 +64,7 @@ def new_template():
                 title=form.title.data,
                 description=form.description.data,
                 filename=fname,
+                category=ClientCategory[form.category.data],
                 owner_id=current_user.id
             )
             db.session.add(tmpl)

--- a/app/templates/dashboard_master.html
+++ b/app/templates/dashboard_master.html
@@ -5,12 +5,13 @@
 <a class="btn btn-primary mb-3" href="{{ url_for('main.new_template') }}">+ New Template</a>
 
 <table class="table table-hover">
-  <thead><tr><th>ID</th><th>Title</th><th>Created</th><th>Submissions</th></tr></thead>
+  <thead><tr><th>ID</th><th>Title</th><th>Category</th><th>Created</th><th>Submissions</th></tr></thead>
   <tbody>
     {% for t in templates %}
     <tr>
       <td>{{ t.id }}</td>
       <td>{{ t.title }}</td>
+      <td>{{ t.category.value }}</td>
       <td>{{ t.created_at.strftime('%Y-%m-%d') }}</td>
       <td>
         {% if t.submissions %}

--- a/app/templates/new_template.html
+++ b/app/templates/new_template.html
@@ -13,6 +13,9 @@
   <div class="mb-3">
     {{ form.file.label(class="form-label") }} {{ form.file(class="form-control") }}
   </div>
+  <div class="mb-3">
+    {{ form.category.label(class="form-label") }} {{ form.category(class="form-select") }}
+  </div>
   {{ form.submit(class="btn btn-primary") }}
 </form>
 {% endblock %}

--- a/app/templates/register.html
+++ b/app/templates/register.html
@@ -16,6 +16,9 @@
   <div class="mb-3">
     {{ form.role.label(class="form-label") }} {{ form.role(class="form-select") }}
   </div>
+  <div class="mb-3">
+    {{ form.category.label(class="form-label") }} {{ form.category(class="form-select") }}
+  </div>
   {{ form.submit(class="btn btn-primary") }}
 </form>
 {% endblock %}


### PR DESCRIPTION
## Summary
- categorize users and templates by facility type
- filter client dashboard by category
- allow Masters to specify target category for templates
- show template category in master dashboard

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684df97fb8c88327889d1d0ce16875a7